### PR TITLE
fixed security_content_ctime macro

### DIFF
--- a/macros/security_content_ctime.yml
+++ b/macros/security_content_ctime.yml
@@ -1,5 +1,5 @@
 arguments:
   - field
-definition: '`ctime($field$,"%m/%d/%Y %H:%M:%S")`'
+definition: 'convert timeformat="%m/%d/%Y %H:%M:%S" ctime($field$)'
 description: convert epoch time to string
 name: security_content_ctime


### PR DESCRIPTION
The security_content_ctime macro was using a ctime macro instead of the ctime function.
This change was successfully tested with a newly built Attack Range. 