### PR TITLE
removing index and keeping source

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ Before you begin, follow the steps to install **dependencies and pre-commit hook
 
 For a more detailed explanation on how to contribute to the project, please see ["Contributing"](#Contributing)
 
+# Latest Feature
+
+ESCU 1.0.46 recently introduced a concept of input(pre-filter) and output(post-filter) macros for each of our detection search. The intention behind introducing these macros is primarily to help our users to update the macro definition “once” and those changes will be applicable across all detections that leverage that macro and  local to your Splunk Environment.
+
+**input(pre-filter):** This macro is to  specify your environment-specific configurations (index, source, sourcetype, etc.) to get the specific data sources that you would like to bring in. Replace the macro definition with configurations for your Splunk environment.
+
+**output(post-filter):** This macro is to  specify your environment-specific values (eg: dest, user), to filter out known false positives.. Replace the macro definition with values that you’d like to exclude from detection results. Think of this as a whitelisting/blacklisting using macros.
+
+Note: we are currently working on coming up with a good naming convention and making this consistent across all our detections, investigations and baselines
+
+
 # Security Content Layout
 ![](docs/static/structure.png)
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ Follow the instructions below to get started.
 
 Manifests contain a number of mandatory and optional fields. You can see the full field list for each piece of content [here](https://github.com/splunk/security-content/tree/develop/docs#spec-documentation).
 
+# Customize to your Environment
+
+After release [1.0.46](https://github.com/splunk/security-content/releases) we introduced a concept of input(pre-filter) and output(post-filter) macros for each of our detection search. The intention behind introducing these macros is primarily to help our users to update the macro definition “once” and those changes will be applicable across all detections that leverage that macro and  local to your Splunk Environment.
+
+**input(pre-filter):** This macro is to  specify your environment-specific configurations (index, source, sourcetype, etc.) to get the specific data sources that you would like to bring in. Replace the macro definition with configurations for your Splunk environment.
+
+**output(post-filter):** This macro is to  specify your environment-specific values (eg: dest, user), to filter out known false positives.. Replace the macro definition with values that you’d like to exclude from detection results. Think of this as a whitelisting/blacklisting using macros.
+
+Note: we are currently working on coming up with a better naming convention and making this consistent across all our detections, investigations and baselines. Suggestions are welcomed :stuck_out_tongue:
+
 # Writing Content
 Before you begin, follow the steps to install **dependencies and pre-commit hooks** under ["Developing"](https://github.com/splunk/security-content#developing). 
 
@@ -54,17 +64,6 @@ Before you begin, follow the steps to install **dependencies and pre-commit hook
 3. Make a pull request. The pull request will trigger CircleCI, a continuous-integration app thatintegrates with a VCS and automatically runs a series of steps every time that it detects a change to your repository. A CircleCI build consists of a series of steps, usually Dependencies, Testing, and Deployment. If your tests pass, you're good to go! If the CircleCI check fails, refer to [troubleshooting](https://github.com/splunk/security-content#troubleshooting).  
 
 For a more detailed explanation on how to contribute to the project, please see ["Contributing"](#Contributing)
-
-# Latest Feature
-
-ESCU 1.0.46 recently introduced a concept of input(pre-filter) and output(post-filter) macros for each of our detection search. The intention behind introducing these macros is primarily to help our users to update the macro definition “once” and those changes will be applicable across all detections that leverage that macro and  local to your Splunk Environment.
-
-**input(pre-filter):** This macro is to  specify your environment-specific configurations (index, source, sourcetype, etc.) to get the specific data sources that you would like to bring in. Replace the macro definition with configurations for your Splunk environment.
-
-**output(post-filter):** This macro is to  specify your environment-specific values (eg: dest, user), to filter out known false positives.. Replace the macro definition with values that you’d like to exclude from detection results. Think of this as a whitelisting/blacklisting using macros.
-
-Note: we are currently working on coming up with a good naming convention and making this consistent across all our detections, investigations and baselines
-
 
 # Security Content Layout
 ![](docs/static/structure.png)
@@ -105,7 +104,8 @@ To automatically generate docs from schema:
 2. Enter `jsonschema2md -d spec/v2/detections.spec.json -o docs`.
 
 # Troubleshooting
-#### Our Automated Tests
+
+### Our Automated Tests
 1. [CI](https://github.com/splunk/security-content/blob/44946063173f7bc9921f0da0aa62139c084d1c51/.circleci/config.yml#L27) validates that the content was written to spec using [`validate.py`](https://github.com/splunk/security-content/blob/runstory/bin/generate.py). To run validation manually, run: `python bin/validate.py --path . --verbose`.
 2. [CI](https://github.com/splunk/security-content/blob/44946063173f7bc9921f0da0aa62139c084d1c51/.circleci/config.yml#L60) generates Splunk configuration files using [`generate.py`](https://github.com/splunk/security-content/blob/develop/bin/generate.py). If you want to export Splunk .conf files manually from the content, run `python bin/generate.py --path . --output package --verbose`.
 3. [CI](https://github.com/splunk/security-content/blob/44946063173f7bc9921f0da0aa62139c084d1c51/.circleci/config.yml#L107) builds a DA-ESS-ContentUpdate Splunk package using the [Splunk Packaging Toolkit](http://dev.splunk.com/view/packaging-toolkit/SP-CAAAE9V). 

--- a/detections/access_lsass_memory_for_dump_creation.yml
+++ b/detections/access_lsass_memory_for_dump_creation.yml
@@ -41,7 +41,7 @@ eli5: dbgcore.dll is a specifc DLL for Windows core debugging. It is used to obt
   can be created with tools such as Windows Task Manager or procdump.
 entities:
   - dest
-how_to_implement: 'This search needs Sysmon Logs and a Sysmon configuration, which includes EventCode 10 for lsass.exe'
+how_to_implement: This search requires Sysmon Logs and a Sysmon configuration, which includes EventCode 10 for lsass.exe. This search uses an input macro named `sysmon`. We strongly recommend that you specify your environment-specific configurations (index, source, sourcetype, etc.) for Windows Sysmon logs. Replace the macro definition with configurations for your Splunk environment. The search also uses a post-filter macro designed to filter out known false positives.
 id: fb4c31b0-13e8-4155-8aa5-24de4b8d6717
 investigations:
   - id: 5de385bf-4f1e-404e-9b67-92d162ff8938ad

--- a/detections/create_remote_thread_into_lsass.yml
+++ b/detections/create_remote_thread_into_lsass.yml
@@ -39,7 +39,7 @@ eli5: This search detects the creation of a remote thread into LSASS (Local Secu
   This technique can be used by attackers to inject code into LSASS and dump the memory in order to obtain credentials.
 entities:
   - dest
-how_to_implement: 'This search needs Sysmon Logs with a Sysmon configuration, which includes EventCode 8 with lsass.exe'
+how_to_implement: 'This search needs Sysmon Logs with a Sysmon configuration, which includes EventCode 8 with lsass.exe. This search uses an input macro named `sysmon`. We strongly recommend that you specify your environment-specific configurations (index, source, sourcetype, etc.) for Windows Sysmon logs. Replace the macro definition with configurations for your Splunk environment. The search also uses a post-filter macro designed to filter out known false positives.'
 id: 67d4dbef-9564-4699-8da8-03a151529edc
 investigations:
   - id: 5de385bf-4f1e-404e-9b67-92d162ff8938ad

--- a/detections/creation_of_shadow_copy_with_wmic_and_powershell.yml
+++ b/detections/creation_of_shadow_copy_with_wmic_and_powershell.yml
@@ -40,7 +40,7 @@ eli5: The ntds.dit file contains the Active Directory (AD) database. This file c
   of a shadow copy using wmic, which is executed by Powershell.
 entities:
   - dest
-how_to_implement: You must enable Powershell scriptblock logging in order to detect this attack.
+how_to_implement: You must enable Powershell scriptblock logging in order to detect this attack.This search uses an input macro named `sysmon`. We strongly recommend that you specify your environment-specific configurations (index, source, sourcetype, etc.) for Windows Sysmon logs. Replace the macro definition with configurations for your Splunk environment. The search also uses a post-filter macro designed to filter out known false positives.
 id: 2ed8b538-d284-449a-be1d-82ad1dbd186b
 investigations:
   - id: 5de385bf-4f1e-404e-9b67-92d162ff8938ad

--- a/detections/detect_credential_dumping_through_LSASS_access.yml
+++ b/detections/detect_credential_dumping_through_LSASS_access.yml
@@ -41,7 +41,7 @@ eli5: This search looks for LSASS access using Credential Dumping tools by detec
   This will for example detect the use of sekurlsa::logonpasswords in Mimikatz.
 entities:
   - dest
-how_to_implement: 'This search needs Sysmon Logs and a sysmon configuration, which includes EventCode 10 with lsass.exe'
+how_to_implement: 'This search needs Sysmon Logs and a sysmon configuration, which includes EventCode 10 with lsass.exe. This search uses an input macro named `sysmon`. We strongly recommend that you specify your environment-specific configurations (index, source, sourcetype, etc.) for Windows Sysmon logs. Replace the macro definition with configurations for your Splunk environment. The search also uses a post-filter macro designed to filter out known false positives.'
 id: 2c365e57-4414-4540-8dc0-73ab10729996
 investigations:
   - id: 5de385bf-4f1e-404e-9b67-92d162ff8938ad

--- a/detections/detect_mimikatz_using_loaded_images.yml
+++ b/detections/detect_mimikatz_using_loaded_images.yml
@@ -38,7 +38,7 @@ detect:
 eli5: This search looks for loaded images (dll) unique for Mimikatz using Sysmon EventCode 7 logs.
 entities:
   - dest
-how_to_implement: 'This search needs Sysmon Logs and a sysmon configuration, which includes EventCode 7 with powershell.exe'
+how_to_implement: 'This search needs Sysmon Logs and a sysmon configuration, which includes EventCode 7 with powershell.exe. This search uses an input macro named `sysmon`. We strongly recommend that you specify your environment-specific configurations (index, source, sourcetype, etc.) for Windows Sysmon logs. Replace the macro definition with configurations for your Splunk environment. The search also uses a post-filter macro designed to filter out known false positives.'
 id: 29e307ba-40af-4ab2-91b2-3c6b392bbba0
 investigations:
   - id: 5de385bf-4f1e-404e-9b67-92d162ff8938ad

--- a/detections/unsigned_image_loaded_by_LSASS.yml
+++ b/detections/unsigned_image_loaded_by_LSASS.yml
@@ -41,7 +41,7 @@ eli5: This search detects unsigned images loaded by LSASS (Local Security Authri
   This can be an indicator for credential dumping using tools like Windows Credential Editor.
 entities:
   - dest
-how_to_implement: 'This search needs Sysmon Logs with a sysmon configuration, which includes EventCode 7 with lsass.exe'
+how_to_implement: 'This search needs Sysmon Logs with a sysmon configuration, which includes EventCode 7 with lsass.exe. This search uses an input macro named `sysmon`. We strongly recommend that you specify your environment-specific configurations (index, source, sourcetype, etc.) for Windows Sysmon logs. Replace the macro definition with configurations for your Splunk environment. The search also uses a post-filter macro designed to filter out known false positives.'
 id: 56ef054c-76ef-45f9-af4a-a634695dcd65
 investigations:
   - id: 5de385bf-4f1e-404e-9b67-92d162ff8938ad

--- a/investigations/investigate_pass_the_hash_attempts.yml
+++ b/investigations/investigate_pass_the_hash_attempts.yml
@@ -9,7 +9,7 @@ data_metadata:
 description: This search hunts for dumped NTLM hashes used for pass the hash.
 entities:
   - dest
-how_to_implement: To successfully implement this search you need be ingesting windows security logs.
+how_to_implement: To successfully implement this search you need be ingesting windows security logs. This search uses an input macro named `wineventlog_security`. We strongly recommend that you specify your environment-specific configurations (index, source, sourcetype, etc.) for Windows Security logs. Replace the macro definition with configurations for your Splunk environment. The search also uses a post-filter macro designed to filter out known false positives.
 id: ed3fff45-cba6-4990-983f-6fac72bee659
 investigate:
   splunk:

--- a/investigations/investigate_pass_the_ticket_attempts.yml
+++ b/investigations/investigate_pass_the_ticket_attempts.yml
@@ -9,7 +9,8 @@ data_metadata:
 description: This search hunts for dumped kerberos ticket from LSASS memory.
 entities:
   - dest
-how_to_implement: To successfully implement this search you need to be ingesting windows security logs.
+how_to_implement: To successfully implement this search you need to be ingesting windows security logs. This search uses an input macro named `wineventlog_security`. We strongly recommend that you specify your environment-specific configurations (index, source, sourcetype, etc.) for Windows Security logs. Replace the macro definition with configurations for your Splunk environment. The search also uses a post-filter macro designed to filter out known false positives.
+
 id: 990007ad-d798-4b29-ab2f-f0034144c937
 investigate:
   splunk:

--- a/macros/sysmon.yml
+++ b/macros/sysmon.yml
@@ -1,3 +1,3 @@
-definition: source="WinEventLog:Microsoft-Windows-Sysmon/Operational"
+definition: 
 description: customer specific splunk configurations(eg- index, source, sourcetype) for Windows Sysmon Logs
 name: sysmon

--- a/macros/sysmon.yml
+++ b/macros/sysmon.yml
@@ -1,3 +1,3 @@
-definition: source="WinEventLog:Microsoft-Windows-Sysmon/Operational"
+definition: sourcetype="XmlWinEventLog:Microsoft-Windows-Sysmon/Operational"
 description: customer specific splunk configurations(eg- index, source, sourcetype) for Windows Sysmon Logs. Replace the macro definition with configurations for your Splunk Environmnent.
 name: sysmon

--- a/macros/sysmon.yml
+++ b/macros/sysmon.yml
@@ -1,2 +1,3 @@
-description: customer specific splunk configurations(eg- index, source, sourcetype) for Windows Sysmon Logs
+definition: source="WinEventLog:Microsoft-Windows-Sysmon/Operational"
+description: customer specific splunk configurations(eg- index, source, sourcetype) for Windows Sysmon Logs. Replace the macro definition with configurations for your Splunk Environmnent.
 name: sysmon

--- a/macros/sysmon.yml
+++ b/macros/sysmon.yml
@@ -1,3 +1,3 @@
-definition: index=win source="WinEventLog:Microsoft-Windows-Sysmon/Operational"
-description: customer specific splunk configurations for Windows Sysmon Logs
+definition: source="WinEventLog:Microsoft-Windows-Sysmon/Operational"
+description: customer specific splunk configurations(eg- index, source, sourcetype) for Windows Sysmon Logs
 name: sysmon

--- a/macros/sysmon.yml
+++ b/macros/sysmon.yml
@@ -1,3 +1,2 @@
-definition: 
 description: customer specific splunk configurations(eg- index, source, sourcetype) for Windows Sysmon Logs
 name: sysmon

--- a/macros/wineventlog_security.yml
+++ b/macros/wineventlog_security.yml
@@ -1,3 +1,3 @@
-definition: index=win source=XmlWinEventLog:Security
-description: customer specific splunk configurations for Windows Event Logs Security
+definition: source=XmlWinEventLog:Security
+description: customer specific splunk configurations(eg- index, source, sourcetype) for Windows Sysmon Logs
 name: wineventlog_security

--- a/macros/wineventlog_security.yml
+++ b/macros/wineventlog_security.yml
@@ -1,3 +1,2 @@
-definition: 
 description: customer specific splunk configurations(eg- index, source, sourcetype) for Windows Sysmon Logs
 name: wineventlog_security

--- a/macros/wineventlog_security.yml
+++ b/macros/wineventlog_security.yml
@@ -1,2 +1,3 @@
-description: customer specific splunk configurations(eg- index, source, sourcetype) for Windows Sysmon Logs
+definition: source="XmlWinEventLog:Security"
+description: Customer specific splunk configurations(eg- index, source, sourcetype) for Windows Event Logs. Replace the macro definition with configurations for your Splunk Environmnent.
 name: wineventlog_security

--- a/macros/wineventlog_security.yml
+++ b/macros/wineventlog_security.yml
@@ -1,3 +1,3 @@
-definition: source="XmlWinEventLog:Security"
+definition: eventtype="wineventlog_security"
 description: Customer specific splunk configurations(eg- index, source, sourcetype) for Windows Event Logs. Replace the macro definition with configurations for your Splunk Environmnent.
 name: wineventlog_security

--- a/macros/wineventlog_security.yml
+++ b/macros/wineventlog_security.yml
@@ -1,3 +1,3 @@
-definition: source=XmlWinEventLog:Security
+definition: 
 description: customer specific splunk configurations(eg- index, source, sourcetype) for Windows Sysmon Logs
 name: wineventlog_security


### PR DESCRIPTION
removing index from the macro file and adding instructions in the descriptions for customizing
currently leveraging sourcetype and eventtype where applicable 

Note: This still would work OOTB in the range since we need "index=*" before thee search executes, opened an issue for that :https://github.com/splunk/attack_range/issues/151

still working on a good solution, but this should work for now
