### PR TITLE
update smb related content.  

### DIFF
--- a/detections/outbound_smb_connections.yml
+++ b/detections/outbound_smb_connections.yml
@@ -36,7 +36,7 @@ detect:
         OR All_Traffic.dest_port=445 OR All_Traffic.app=smb) by All_Traffic.src_ip
         All_Traffic.dest_ip | `drop_dm_object_name("All_Traffic")` | search ( dest_ip!=10.0.0.0/8
         AND dest_ip!=172.16.0.0/12 AND dest_ip!=192.168.0.0/16) | `security_content_ctime(earliest)`|
-        `security_content_ctime(latest)`'
+        `security_content_ctime(latest)` | `outbound_smb_connections_filter` '
       suppress:
         suppress_fields: src_ip
         suppress_period: 28800s
@@ -104,9 +104,13 @@ mappings:
     - Commonly Used Port
     - Credential Access
     - Lateral Movement
+  mitre_technique_id:
+    - T1110
+    - T1135
+    - T1210
   nist:
     - DE.CM
-modification_date: '2018-03-20'
+modification_date: '2020-01-22'
 name: Detect Outbound SMB Traffic
 original_authors:
   - company: Splunk
@@ -116,4 +120,4 @@ references: []
 security_domain: network
 spec_version: 2
 type: splunk
-version: '1.0'
+version: '2.0'

--- a/detections/smb_traffic_spike.yml
+++ b/detections/smb_traffic_spike.yml
@@ -35,7 +35,7 @@ detect:
         "-70m@m"), count, null))) as avg stdev(eval(if(_time<relative_time(maxtime,
         "-70m@m"), count, null))) as stdev by src | eval upperBound=(avg+stdev*2),
         isOutlier=if(count > upperBound AND num_data_samples >=50, 1, 0) | where isOutlier=1
-        | table src count'
+        | table src count | `smb_traffic_spike_filter` '
       suppress:
         suppress_fields: src
         suppress_period: 28800s
@@ -100,9 +100,13 @@ mappings:
     - Execution
     - Command and Control
     - Commonly Used Port
+  mitre_technique_id:
+    - T1110
+    - T1135
+    - T1210
   nist:
     - DE.CM
-modification_date: '2017-09-10'
+modification_date: '2020-01-22'
 name: SMB Traffic Spike
 original_authors:
   - company: Splunk
@@ -112,4 +116,4 @@ references: []
 security_domain: network
 spec_version: 2
 type: splunk
-version: '1.0'
+version: '2.0'

--- a/detections/smb_traffic_spike_mltk.yml
+++ b/detections/smb_traffic_spike_mltk.yml
@@ -37,7 +37,7 @@ detect:
         by _time span=1h, All_Traffic.src | eval HourOfDay=strftime(_time, "%H") |
         eval DayOfWeek=strftime(_time, "%A") | `drop_dm_object_name(All_Traffic)`
         | apply smb_pdfmodel threshold=0.001 | rename "IsOutlier(count)" as isOutlier
-        | search isOutlier > 0 | sort -count | table _time src dest port count'
+        | search isOutlier > 0 | sort -count | table _time src dest port count | `smb_traffic_spike_mltk_filter` '
       suppress:
         suppress_fields: src
         suppress_period: 28800s
@@ -126,9 +126,13 @@ mappings:
     - Execution
     - Command and Control
     - Commonly Used Port
+  mitre_technique_id:
+    - T1110
+    - T1135
+    - T1210
   nist:
     - DE.CM
-modification_date: '2019-05-08'
+modification_date: '2020-01-22'
 name: SMB Traffic Spike - MLTK
 original_authors:
   - company: Splunk
@@ -138,4 +142,4 @@ references: []
 security_domain: network
 spec_version: 2
 type: splunk
-version: '1.0'
+version: '2.0'

--- a/macros/outbound_smb_connections_filter.yml
+++ b/macros/outbound_smb_connections_filter.yml
@@ -1,0 +1,3 @@
+definition: search *
+description: Use this macro to add additional filters for outbound SMB traffic detection
+name: outbound_smb_connections_filter

--- a/macros/smb_traffic_spike_filter.yml
+++ b/macros/smb_traffic_spike_filter.yml
@@ -1,0 +1,3 @@
+definition: search *
+description: Use this macro to add additional filters for SMB traffic spike detection
+name: smb_traffic_spike_filter

--- a/macros/smb_traffic_spike_mltk_filter.yml
+++ b/macros/smb_traffic_spike_mltk_filter.yml
@@ -1,0 +1,3 @@
+definition: search *
+description: Use this macro to add additional filters for SMB traffic spike detection using MLKT
+name: smb_traffic_spike_mltkfilter


### PR DESCRIPTION
The outbound_smb_connections detection works out of the box against attack ID T1110 when testing in the attack range. The other two smb detections did not detect T1110, T1135, T1210 but the detection using MLTK had a problem loading the model on my instance of the attack range.