### PR TITLE
Making color contrast changes for 508 compliance

### DIFF
--- a/package/appserver/static/analytic_story_details.css
+++ b/package/appserver/static/analytic_story_details.css
@@ -169,6 +169,7 @@ h3 {
 
 .kill_chain_tag {
 	background-color: #ed8440;
+	color: #303841;
 }
 
 .attack_tag {


### PR DESCRIPTION
Making changes to resolve the following 508-compliance ticket:
https://jira.splunk.com/browse/SOLNESS-21248

Per Suggestion Spreadsheet:
"20361: Validate User Can Access the Analytic Story Detail Page and all of its Elements (Step 1-6)"

This element (div   class="value_label kill_chain_tag">Actions on   Objectives</div) has insufficient contrast at this conformance level. Expected a contrast ratio of at least 4.5:1, but text in this element has a contrast ratio of 3.75:1. Recommendation:  change text color to #303841