### PR TITLE
new credential dumping detection

### DIFF
--- a/detections/dump_lsass_via_comsvcs_dll.yml
+++ b/detections/dump_lsass_via_comsvcs_dll.yml
@@ -1,0 +1,91 @@
+asset_type: Endpoint
+confidence: high
+creation_date: '2020-02-21'
+data_metadata:
+  data_models:
+    - Endpoint
+  data_source:
+    - Endpoint Intel
+  providing_technologies:
+    - Sysmon
+description: Detect the usage of comsvcs.dll for dumping the lsass process.
+detect:
+  splunk:
+    correlation_rule:
+      notable:
+        nes_fields: user, process_name, process
+        rule_description: An attempt to dump credentials of lsass by $user$ was detected.
+        rule_title: Dump LSASS via comsvcs DLL
+      risk:
+        risk_object: user
+        risk_object_type:
+          - user
+        risk_score: 80
+      macros:
+        - dump_lsass_via_comsvcs_dll_filter
+      schedule:
+        cron_schedule: 0 * * * *
+        earliest_time: -70m@m
+        latest_time: -10m@m
+      search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as lastTime
+        from datamodel=Endpoint.Processes where Processes.process_name=rundll32.exe Processes.process=*comsvcs.dll*
+        Processes.process=*MiniDump* by Processes.user Processes.process_name Processes.process Processes.dest
+        | `drop_dm_object_name(Processes)` | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+        | `dump_lsass_via_comsvcs_dll_filter`'
+      suppress:
+        suppress_fields: process_name, dest
+        suppress_period: 86400s
+eli5: LSASS is the Local Security Authority Subsystem Service, which is responsible for storing the user credentials.
+  There are multiple ways to attack LSASS. This search detects the usage of comsvcs.dll for dumping the LSASS process.
+entities:
+  - dest
+how_to_implement: You must be ingesting endpoint data that tracks process activity,
+  including parent-child relationships from your endpoints, to populate the Endpoint
+  data model in the Processes node. The command-line arguments are mapped to the "process"
+  field in the Endpoint data model.
+id: 8943b567-f14d-4ee8-a0bb-2121d4ce3184
+investigations:
+  - id: 5de385bf-4f1e-404e-9b67-92d162ff8938ad
+    name: Investigate Previous Unseen User
+    type: splunk
+  - id: 097e8030-8662-4254-a735-bf0bdda696e3
+    name: Investigate Failed Logins for Multiple Destinations
+    type: splunk
+  - id: ed3fff45-cba6-4990-983f-6fac72bee659
+    name: Investigate Pass the Hash Attempts
+    type: splunk
+  - id: 990007ad-d798-4b29-ab2f-f0034144c937
+    name: Investigate Pass the Ticket Attempts
+    type: splunk
+known_false_positives: None identified.
+maintainers:
+  - company: Splunk
+    email: pbareiss@splunk.com
+    name: Patrick Bareiss
+mappings:
+  cis20:
+    - CIS 3
+    - CIS 5
+    - CIS 16
+  kill_chain_phases:
+    - Actions on Objectives
+  mitre_technique_id:
+    - T1003
+  mitre_attack:
+    - Credential Access
+    - Credential Dumping
+  nist:
+    - DE.CM
+modification_date: '2020-02-21'
+name: Dump LSASS via comsvcs DLL
+original_authors:
+  - company: Splunk
+    email: pbareiss@splunk.com
+    name: Patrick Bareiss
+references:
+  - https://modexp.wordpress.com/2019/08/30/minidumpwritedump-via-com-services-dll/
+  - https://twitter.com/SBousseaden/status/1167417096374050817
+security_domain: endpoint
+spec_version: 2
+type: splunk
+version: '1.0'

--- a/macros/dump_lsass_via_comsvcs_dll_filter.yml
+++ b/macros/dump_lsass_via_comsvcs_dll_filter.yml
@@ -1,0 +1,3 @@
+definition: search *
+description: Use this macro to add additional filter for dump lsass via comsvcs dll filter
+name: dump_lsass_via_comsvcs_dll_filter

--- a/stories/credential_dumping.yml
+++ b/stories/credential_dumping.yml
@@ -41,6 +41,9 @@ detections:
   - detection_id: c5eac648-fae0-4263-91a6-773df1f4c903
     name: Credential Dumping via Symlink to Shadowcopy
     type: splunk
+  - detection_id: 8943b567-f14d-4ee8-a0bb-2121d4ce3184
+    name: Dump LSASS via comsvcs DLL
+    type: splunk
 id: 854d78bf-d0e2-4f4e-b05c-640905f86d7a
 maintainers:
   - company: Splunk


### PR DESCRIPTION
I developed a new detection for the credential dumping story. 
It will detect the usage of comsvcs.dll in combination of rundll32.

For testing you can run the attack described here:
https://modexp.wordpress.com/2019/08/30/minidumpwritedump-via-com-services-dll/

