### PR TITLE
Access LSASS Memory for Dump Creation

### DIFF
--- a/package/default/savedsearches.conf
+++ b/package/default/savedsearches.conf
@@ -619,7 +619,7 @@ quantity = 0
 realtime_schedule = 0
 schedule_window = auto
 is_visible = false
-search = `sysmon` EventCode=10 TargetImage=*lsass.exe CallTrace=*dbgcore.dll* | stats count min(_time) as firstTime max(_time) as lastTime by Computer, TargetImage, TargetProcessId, SourceImage, SourceProcessId | rename Computer as dest | `security_content_ctime(firstTime)`| `security_content_ctime(lastTime)` | `access_lsass_memory_for_dump_creation_filter` 
+search = `sysmon` EventCode=10 TargetImage=*lsass.exe CallTrace=*dbgcore.dll* OR CallTrace=*dbghelp.dll* | stats count min(_time) as firstTime max(_time) as lastTime by Computer, TargetImage, TargetProcessId, SourceImage, SourceProcessId | rename Computer as dest | `security_content_ctime(firstTime)`| `security_content_ctime(lastTime)` | `access_lsass_memory_for_dump_creation_filter` 
 
 [ESCU - Attempt To Add Certificate To Untrusted Store - Rule]
 action.escu = 0


### PR DESCRIPTION
OR CallTrace=*dbghelp.dll* " added this dll to search for Windows 7 machines. reference pages https://blog.menasec.net/2019/02/threat-hunting-21-procdump-or-taskmgr.html