### PR TITLE
CRL-1734: updating spl with escape chars and better output

### DIFF
--- a/detections/netsh_launching_process.yml
+++ b/detections/netsh_launching_process.yml
@@ -37,9 +37,9 @@ detect:
         earliest_time: -70m@m
         latest_time: -10m@m
       search: '| tstats `security_content_summariesonly` count values(Processes.process) as process min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes where Processes.parent_process="*C:\\Windows\\System32\\netsh.exe*" by Processes.user Processes.dest Processes.parent_process Processes.parent_process_name Processes.process_name 
-| `drop_dm_object_name("Processes")`
-| `security_content_ctime(firstTime)`
-| `security_content_ctime(lastTime)`'
+        | `drop_dm_object_name("Processes")`
+        | `security_content_ctime(firstTime)`
+        | `security_content_ctime(lastTime)`'
       suppress:
         suppress_fields: dest, process
         suppress_period: 86400s
@@ -95,7 +95,7 @@ mappings:
   nist:
     - PR.PT
     - DE.CM
-modification_date: '2018-11-02'
+modification_date: '2020-03-02'
 name: Processes created by netsh
 original_authors:
   - company: Splunk
@@ -105,4 +105,4 @@ references: []
 security_domain: endpoint
 spec_version: 2
 type: splunk
-version: '2.0'
+version: '3.0'

--- a/detections/netsh_launching_process.yml
+++ b/detections/netsh_launching_process.yml
@@ -36,18 +36,14 @@ detect:
         cron_schedule: 0 * * * *
         earliest_time: -70m@m
         latest_time: -10m@m
-      search: '| tstats `security_content_summariesonly` count values(Processes.process) min(_time)
-        as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes where
-        Processes.parent_process="C:\Windows\System32\
-
-        etsh.exe" by Processes.parent_process Processes.process_name Processes.user
-        Processes.dest | `drop_dm_object_name("Processes")` | `security_content_ctime(firstTime)`|`security_content_ctime(lastTime)`'
+      search: '| tstats `security_content_summariesonly` count values(Processes.process) as process min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes where Processes.parent_process="*C:\\Windows\\System32\\netsh.exe*" by Processes.user Processes.dest Processes.parent_process Processes.parent_process_name Processes.process_name 
+| `drop_dm_object_name("Processes")`
+| `security_content_ctime(firstTime)`
+| `security_content_ctime(lastTime)`'
       suppress:
         suppress_fields: dest, process
         suppress_period: 86400s
-eli5: 'This search looks for all processes with the parent process "c:\Windows\System32\
-
-  etsh.exe" and returns the process, the command line used to execute it, the host
+eli5: 'This search looks for all processes with the parent process "c:\Windows\System32\netsh.exe" and returns the process, the command line used to execute it, the host
   name, and the user context under which it ran.'
 entities:
   - dest


### PR DESCRIPTION
updated this part

Processes.parent_process="*C:\\Windows\\System32\\netsh.exe*"