### PR TITLE
Update reg_manipulating_services.yml

### DIFF
--- a/detections/reg_manipulating_services.yml
+++ b/detections/reg_manipulating_services.yml
@@ -20,7 +20,7 @@ detect:
       notable:
         nes_fields: dest, process
         rule_description: A registry key associated with Windows services was modified
-          via reg.exe on $dest$ by $src_user$.
+          via reg.exe on $dest$ by $user$.
         rule_title: Modification of Windows Services Via Reg.exe on $dest$
       risk:
         risk_object: dest
@@ -33,7 +33,7 @@ detect:
         latest_time: -10m@m
       search: '| tstats `security_content_summariesonly` count min(_time) as firstTime max(_time) as
         lastTime values(Processes.process_name) as process_name values(Processes.parent_process_name)
-        as parent_process_name FROM datamodel=Endpoint.Processes where Processes.process_name
+        as parent_process_name values(Processes.user) as user FROM datamodel=Endpoint.Processes where Processes.process_name
         = reg.exe by Processes.process_id Processes.dest | `drop_dm_object_name("Processes")`
         | `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)` | join [| tstats `security_content_summariesonly`
         values(Registry.registry_path) as registry_path count  FROM datamodel=Endpoint.Registry


### PR DESCRIPTION
$src_user$ from notable description did not exist, so needed to go.

At the same time, proposed to add the user(s) in to the stats table and change the description to reference $user$ instead.