### PR TITLE
Removed data model module name from output

### DIFF
--- a/detections/spectre_and_meltdown_vulnerable_systems.yml
+++ b/detections/spectre_and_meltdown_vulnerable_systems.yml
@@ -12,7 +12,8 @@ author: David Dorsey, Splunk
 search: '| tstats `security_content_summariesonly` min(_time) as firstTime max(_time)
   as lastTime from datamodel=Vulnerabilities where Vulnerabilities.cve ="CVE-2017-5753"
   OR Vulnerabilities.cve ="CVE-2017-5715" OR Vulnerabilities.cve ="CVE-2017-5754"
-  by Vulnerabilities.dest| `security_content_ctime(firstTime)` | `security_content_ctime(lastTime)`
+  by Vulnerabilities.dest | `drop_dm_object_name(Vulnerabilities)` | `security_content_ctime(firstTime)`
+  | `security_content_ctime(lastTime)`
   | `spectre_and_meltdown_vulnerable_systems_filter`'
 known_false_positives: It is possible that your vulnerability scanner is not detecting
   that the patches have been applied.


### PR DESCRIPTION
Search didn't drop the data model name. Now it does.