### PR TITLE
Changed WHERE clause to fix broken search and renamed a field names for readability.

### DIFF
--- a/detections/processes_launching_netsh.yml
+++ b/detections/processes_launching_netsh.yml
@@ -13,7 +13,7 @@ how_to_implement: To successfully implement this search, you must be ingesting d
 type: ESCU
 references: []
 author: Bhavin Patel, Splunk
-search: '| tstats `security_content_summariesonly` count values(Processes.process)
+search: '| tstats `security_content_summariesonly` count values(Processes.process_name) AS Processes.process
   min(_time) as firstTime max(_time) as lastTime from datamodel=Endpoint.Processes
   where Processes.process=netsh.exe by Processes.parent_process Processes.process_name
   Processes.user Processes.dest | `drop_dm_object_name("Processes")` | `security_content_ctime(firstTime)`|`security_content_ctime(lastTime)`


### PR DESCRIPTION
Fixed the `where` clause that was searching the incorrect field.  Also renamed `values(Processes.process)` to `Processes.process` for readability.