### PR TITLE
converted lookup to collection

### DIFF
--- a/lookups/api_call_by_user_baseline.csv
+++ b/lookups/api_call_by_user_baseline.csv
@@ -1,1 +1,0 @@
-arn,numDataPoints,avgApiCalls,stdevApiCalls

--- a/lookups/api_call_by_user_baseline.yml
+++ b/lookups/api_call_by_user_baseline.yml
@@ -1,4 +1,5 @@
-description: A lookup file that will contain the baseline information for number of
+description: A collection that will contain the baseline information for number of
   AWS API calls per user
-filename: api_call_by_user_baseline.csv
+collection: api_call_by_user_baseline
 name: api_call_by_user_baseline
+fields_list: arn, numDataPoints, avgApiCalls, stdevApiCalls

--- a/lookups/api_call_by_user_baseline.yml
+++ b/lookups/api_call_by_user_baseline.yml
@@ -2,4 +2,4 @@ description: A collection that will contain the baseline information for number 
   AWS API calls per user
 collection: api_call_by_user_baseline
 name: api_call_by_user_baseline
-fields_list: arn, numDataPoints, avgApiCalls, stdevApiCalls
+fields_list: arn, latestCount, numDataPoints, avgApiCalls, stdevApiCalls


### PR DESCRIPTION
this was reported to have issues during bundle replication since the lookup gets really big. 