### PR TITLE
[TR-82] add logic for updating risk parameters in saved searches.conf

### DIFF
--- a/bin/generate.py
+++ b/bin/generate.py
@@ -95,7 +95,7 @@ def generate_savedsearches_conf(detections, response_tasks, baselines, deploymen
             if len(nes_fields) > 0:
                 detection['nes_fields'] = nes_fields
 
-        keys = ['mitre_attack', 'kill_chain_phases', 'cis20', 'nist', 'security_domain', 'asset_type', 'risk_object', 'risk_object_type', 'risk_score']
+        keys = ['mitre_attack', 'kill_chain_phases', 'cis20', 'nist']
         mappings = {}
         for key in keys:
             if key == 'mitre_attack':

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -88,9 +88,10 @@ def generate_savedsearches_conf(detections, response_tasks, baselines, deploymen
             if len(nes_fields) > 0:
                 detection['nes_fields'] = nes_fields
 
-        keys = ['mitre_attack', 'kill_chain_phases', 'cis20', 'nist']
+        keys = ['mitre_attack', 'kill_chain_phases', 'cis20', 'nist', 'security_domain', 'asset_type', 'risk_object', 'risk_object_type', 'risk_score']
         mappings = {}
         for key in keys:
+            #print(key)
             if key == 'mitre_attack':
                 if 'mitre_attack_id' in detection['tags']:
                     mappings[key] = detection['tags']['mitre_attack_id']
@@ -98,6 +99,16 @@ def generate_savedsearches_conf(detections, response_tasks, baselines, deploymen
                 if key in detection['tags']:
                     mappings[key] = detection['tags'][key]
         detection['mappings'] = mappings
+
+        if 'risk_object' in detection['tags']:
+            detection['risk_object'] = detection['tags']['risk_object']
+            print(detection['tags']['risk_object'])
+        if 'risk_object_type' in detection['tags']:
+            detection['risk_object_type'] = detection['tags']['risk_object_type']
+            print(detection['tags']['risk_object_type'])
+        if 'risk_score' in detection['tags']:
+            detection['risk_score'] = detection['tags']['risk_score']
+            print(detection['tags']['risk_score'])
 
     for baseline in baselines:
         data_model = parse_data_models_from_search(baseline['search'])

--- a/bin/generate.py
+++ b/bin/generate.py
@@ -74,6 +74,13 @@ def generate_collections_conf(lookups):
 
 
 def generate_savedsearches_conf(detections, response_tasks, baselines, deployments):
+    '''
+    @param detections: input list of individual YAML detections in detections/ directory
+    @param response_tasks:
+    @param baselines:
+    @param deployments:
+    @return: the savedsearches.conf file located in package/default/
+    '''
 
     for detection in detections:
         # parse out data_models
@@ -91,7 +98,6 @@ def generate_savedsearches_conf(detections, response_tasks, baselines, deploymen
         keys = ['mitre_attack', 'kill_chain_phases', 'cis20', 'nist', 'security_domain', 'asset_type', 'risk_object', 'risk_object_type', 'risk_score']
         mappings = {}
         for key in keys:
-            #print(key)
             if key == 'mitre_attack':
                 if 'mitre_attack_id' in detection['tags']:
                     mappings[key] = detection['tags']['mitre_attack_id']
@@ -102,13 +108,10 @@ def generate_savedsearches_conf(detections, response_tasks, baselines, deploymen
 
         if 'risk_object' in detection['tags']:
             detection['risk_object'] = detection['tags']['risk_object']
-            print(detection['tags']['risk_object'])
         if 'risk_object_type' in detection['tags']:
             detection['risk_object_type'] = detection['tags']['risk_object_type']
-            print(detection['tags']['risk_object_type'])
         if 'risk_score' in detection['tags']:
             detection['risk_score'] = detection['tags']['risk_score']
-            print(detection['tags']['risk_score'])
 
     for baseline in baselines:
         data_model = parse_data_models_from_search(baseline['search'])

--- a/bin/jinja2_templates/savedsearches.j2
+++ b/bin/jinja2_templates/savedsearches.j2
@@ -41,6 +41,16 @@ action.escu.providing_technologies = []
 {% endif %}
 {% if detection.tags.analytics_story is defined %}
 action.escu.analytic_story = {{ detection.tags.analytics_story | tojson }}
+
+{% if detection.tags.risk_object is defined %}
+action.risk = 1
+action.risk.param._risk_object = {{ detection.tags.risk_object }}
+action.risk.param._risk_object_type = {{ detection.tags.risk_object_type }}
+action.risk.param._risk_score = {{ detection.tags.risk_score }}
+action.risk.param.verbose = 0
+{% endif %}
+
+
 {% else %}
 action.escu.analytic_story = []
 {% endif %}

--- a/bin/jinja2_templates/savedsearches.j2
+++ b/bin/jinja2_templates/savedsearches.j2
@@ -78,13 +78,6 @@ action.email.to = {{ detection.deployment.alert_action.email.to }}
 action.email.message.alert = {{ detection.deployment.alert_action.email.message | custom_jinja2_enrichment_filter(detection) }}
 action.email.useNSSubject = 1
 {% endif %}
-{% if detection.deployment.alert_action.risk is defined %}
-action.risk = 1
-action.risk.param._risk_object = dest
-action.risk.param._risk_object_type = system
-action.risk.param._risk_score = 30
-action.risk.param.verbose = 0
-{% endif %}
 alert.digest_mode = 1
 action.escu.earliest_time_offset = 3600
 action.escu.latest_time_offset = 86400

--- a/bin/jinja2_templates/savedsearches.j2
+++ b/bin/jinja2_templates/savedsearches.j2
@@ -41,7 +41,6 @@ action.escu.providing_technologies = []
 {% endif %}
 {% if detection.tags.analytics_story is defined %}
 action.escu.analytic_story = {{ detection.tags.analytics_story | tojson }}
-
 {% if detection.tags.risk_object is defined %}
 action.risk = 1
 action.risk.param._risk_object = {{ detection.tags.risk_object }}
@@ -49,8 +48,6 @@ action.risk.param._risk_object_type = {{ detection.tags.risk_object_type }}
 action.risk.param._risk_score = {{ detection.tags.risk_score }}
 action.risk.param.verbose = 0
 {% endif %}
-
-
 {% else %}
 action.escu.analytic_story = []
 {% endif %}

--- a/detections/abnormally_high_aws_instances_launched_by_user.yml
+++ b/detections/abnormally_high_aws_instances_launched_by_user.yml
@@ -37,3 +37,6 @@ tags:
   - DE.AE
   security_domain: network
   asset_type: AWS Instance
+  risk_object: userName
+  risk_object_type: user
+  risk_score: 50

--- a/docs/spec/detections.spec.md
+++ b/docs/spec/detections.spec.md
@@ -27,7 +27,7 @@ schema for detections
 | [tags](#tags) | `object` | **Required**  | No | `{}` | Detection Schema (this schema) |
 | [type](#type) | `string` | **Required**  | No | `""` | Detection Schema (this schema) |
 | [version](#version) | `integer` | **Required**  | No | `0` | Detection Schema (this schema) |
-| [risk_object_field](#risk_object_field) | `string` | **Optional** | No | `""` | ES Schema |
+| [risk_object](#risk_object) | `string` | **Optional** | No | `""` | ES Schema |
 | [risk_object_type](#risk_object_type) | `string` | **Optional** | No | `""` | ES Schema | 
 | [risk_score](#risk_score) | `integer`  | **Optional** | No | `0` | ES Schema |  
 
@@ -328,34 +328,35 @@ An array of key value pairs for tagging
 ```
 
 
-## Risk Object Field
+## Risk Object Tag
 
-Optional tags for risk scoring parameters associated to the detection. The Risk object field is the name of the risk object
+Optional parameter for risk scoring meta-data associated to the detection. The `risk_object` field is the name of the risk object
 corresponding to the type of entity the risk is associated too.  
 
-`risk_object_field`
+`risk_object`
 
 * is **optional**
 * type: `string`
 * default `""`
 * defined in the SSA Schema
 
-## Risk Object Field Values
+## Risk Object Values
 
 Possible field names can take the possible values:  ``risk_system``, ``src``, ``dest``, ``src_user``, ``user``, ``risk_hash``,
 ``risk_network``, ``risk_host``, ``risk_other``.
 
-## Risk Object Field Example 
+## Risk Object Example 
 
 ```json
 {
-  "risk_object_field": "src_user",
+  "risk_object": "src_user",
 }
 ```
 
 ## Risk Object Type
 
-The corresponding entity type for the risk score associated to the optional tag ``risk_object_type``.
+The corresponding entity type for the risk score associated to the optional tag ``risk_object_type``.  This is the type of 
+object assocaited to the value for the tag `risk_object`
 
 `risk_object_type`
 

--- a/docs/spec/detections.spec.md
+++ b/docs/spec/detections.spec.md
@@ -27,10 +27,6 @@ schema for detections
 | [tags](#tags) | `object` | **Required**  | No | `{}` | Detection Schema (this schema) |
 | [type](#type) | `string` | **Required**  | No | `""` | Detection Schema (this schema) |
 | [version](#version) | `integer` | **Required**  | No | `0` | Detection Schema (this schema) |
-| [risk_object](#risk_object) | `string` | **Optional** | No | `""` | ES Schema |
-| [risk_object_type](#risk_object_type) | `string` | **Optional** | No | `""` | ES Schema | 
-| [risk_score](#risk_score) | `integer`  | **Optional** | No | `0` | ES Schema |  
-
 | `*` | any | Additional | Yes | this schema *allows* additional properties |
 
 ## author
@@ -328,83 +324,6 @@ An array of key value pairs for tagging
 ```
 
 
-## Risk Object Tag
-
-Optional parameter for risk scoring meta-data associated to the detection. The `risk_object` field is the name of the risk object
-corresponding to the type of entity the risk is associated too.  
-
-`risk_object`
-
-* is **optional**
-* type: `string`
-* default `""`
-* defined in the SSA Schema
-
-## Risk Object Values
-
-Possible field names can take the possible values:  ``risk_system``, ``src``, ``dest``, ``src_user``, ``user``, ``risk_hash``,
-``risk_network``, ``risk_host``, ``risk_other``.
-
-## Risk Object Example 
-
-```json
-{
-  "risk_object": "src_user",
-}
-```
-
-## Risk Object Type
-
-The corresponding entity type for the risk score associated to the optional tag ``risk_object_type``.  This is the type of 
-object assocaited to the value for the tag `risk_object`
-
-`risk_object_type`
-
-* is **optional**
-* type: `string`
-* default `""`
-* defined in this schema 
-
-## Risk Object Field Types
-
-Possible object types can take the possible values:  ``system``, ``user``, ``hash_values``, ``network_artifacts``, ``host_artifacts``, 
-``other``.
-
-## RBA Risk Object Field Example 
-
-```json
-{
-  "risk_object_type": "system",
-}
-```
-
-## Risk Object Score
-
-The risk score corresponding to ``risk_object_field`` and ``risk_b.
-
-`risk_object_type`
-
-* is **optional**
-* type: `string`
-* default `""`
-* defined in this schema 
-
-## Risk Object Field Types
-
-Possible object types can take the possible values:  ``system``, ``user``, ``hash_values``, ``network_artifacts``, ``host_artifacts``, 
-``other``.
-
-## RBA Risk Object Field Example 
-
-```json
-{
-  "risk_object_type": "system",
-}
-```
- 
- 
-
-
 ## type
 
 type of detection
@@ -459,4 +378,3 @@ version of detection, e.g. 1 or 2 ...
 ```json
 2
 ```
-

--- a/docs/spec/detections.spec.md
+++ b/docs/spec/detections.spec.md
@@ -27,6 +27,10 @@ schema for detections
 | [tags](#tags) | `object` | **Required**  | No | `{}` | Detection Schema (this schema) |
 | [type](#type) | `string` | **Required**  | No | `""` | Detection Schema (this schema) |
 | [version](#version) | `integer` | **Required**  | No | `0` | Detection Schema (this schema) |
+| [risk_object_field](#risk_object_field) | `string` | **Optional** | No | `""` | ES Schema |
+| [risk_object_type](#risk_object_type) | `string` | **Optional** | No | `""` | ES Schema | 
+| [risk_score](#risk_score) | `integer`  | **Optional** | No | `0` | ES Schema |  
+
 | `*` | any | Additional | Yes | this schema *allows* additional properties |
 
 ## author
@@ -322,6 +326,82 @@ An array of key value pairs for tagging
   "custom_key": "custom_value"
 }
 ```
+
+
+## Risk Object Field
+
+Optional tags for risk scoring parameters associated to the detection. The Risk object field is the name of the risk object
+corresponding to the type of entity the risk is associated too.  
+
+`risk_object_field`
+
+* is **optional**
+* type: `string`
+* default `""`
+* defined in the SSA Schema
+
+## Risk Object Field Values
+
+Possible field names can take the possible values:  ``risk_system``, ``src``, ``dest``, ``src_user``, ``user``, ``risk_hash``,
+``risk_network``, ``risk_host``, ``risk_other``.
+
+## Risk Object Field Example 
+
+```json
+{
+  "risk_object_field": "src_user",
+}
+```
+
+## Risk Object Type
+
+The corresponding entity type for the risk score associated to the optional tag ``risk_object_type``.
+
+`risk_object_type`
+
+* is **optional**
+* type: `string`
+* default `""`
+* defined in this schema 
+
+## Risk Object Field Types
+
+Possible object types can take the possible values:  ``system``, ``user``, ``hash_values``, ``network_artifacts``, ``host_artifacts``, 
+``other``.
+
+## RBA Risk Object Field Example 
+
+```json
+{
+  "risk_object_type": "system",
+}
+```
+
+## Risk Object Score
+
+The risk score corresponding to ``risk_object_field`` and ``risk_b.
+
+`risk_object_type`
+
+* is **optional**
+* type: `string`
+* default `""`
+* defined in this schema 
+
+## Risk Object Field Types
+
+Possible object types can take the possible values:  ``system``, ``user``, ``hash_values``, ``network_artifacts``, ``host_artifacts``, 
+``other``.
+
+## RBA Risk Object Field Example 
+
+```json
+{
+  "risk_object_type": "system",
+}
+```
+ 
+ 
 
 
 ## type


### PR DESCRIPTION
(WIP) First cut of logic for adding risk tagging there are a couple open questions I want to synch on in terms of pieces of code for generating saved searches that I would like help with before merged. 


Changes:
-  removing risk alert action from deployments and adding it as tags in detection.yml. tags
- update to /bin/jinja2_templates/savedsearches.j2 for risk annotations.  
- since tags dont have required "keys": example in `detections/abnormally_high_aws_instances_launched_by_user.yml`