### PR TITLE
adding a default panel instead of empty

### DIFF
--- a/bin/jinja2_templates/es_investigations.j2
+++ b/bin/jinja2_templates/es_investigations.j2
@@ -8,7 +8,7 @@ disabled = 0
 {% if story.workbench_panels is defined %}
 panels = {{ story.workbench_panels | tojson }}
 {% else %}
-panels =
+panels = ["panel://workbench_panel_get_notable_info"]
 {% endif %}
 
 {% endfor %}


### PR DESCRIPTION
Due to the panel being empty : https://github.com/splunk/security-content/blob/013649cb6b3d69ee58fc43d44948ca8ff0cb4dc7/bin/jinja2_templates/es_investigations.j2#L11

this issue was reported: https://github.com/splunk/security-content/issues/682


Pushing a fix in this PR: if a story has no response task : then we default to a "Get Notable Info" task