### PR TITLE
formatting yml

### DIFF
--- a/detections/prohibited_apps_spawning_cmdprompt___ssa.yml
+++ b/detections/prohibited_apps_spawning_cmdprompt___ssa.yml
@@ -9,15 +9,12 @@ how_to_implement: "You must be ingesting sysmon logs.
 This search has been modified to process raw sysmon data from attack_range's nxlogs on DSP."
 author: Ignacio Bermudez Corrales, Splunk
 type: SSA
-search: '
-| from read_ssa_enriched_events()
-
+search: '| from read_ssa_enriched_events()
 | eval timestamp=parse_long(ucast(map_get(input_event, "_time"), "string", null))
 | eval process_name=ucast(map_get(input_event, "process_name"), "string", null),
 parent_process=lower(ucast(map_get(input_event, "parent_process_name"), "string", null)),
 dest_user_id=ucast(map_get(input_event, "dest_user_id"), "string", null),
 dest_ip_id=ucast(map_get(input_event, "dest_ip_id"), "string", null)
-
 | where process_name="cmd.exe"
 | rex field=parent_process "(?<field0>[^\\\\]+)$"
 | where field0="winword.exe" OR
@@ -34,13 +31,11 @@ dest_ip_id=ucast(map_get(input_event, "dest_ip_id"), "string", null)
         field0="firefox.exe" OR
         field0="java.exe" OR
         field0="powershell.exe"
-
 | eval start_time=timestamp,
 end_time=timestamp,
 entities=mvappend([dest_ip_id, dest_user_id]),
 body="TBD"
-| into write_ssa_detected_events();
-'
+| into write_ssa_detected_events();'
 eli5: "Obtaining access to the Command-Line Interface (CLI) is typically a primary
          attacker goal. Once an attacker has obtained the ability to execute code on a target
          system, they will often further manipulate the system via commands passed to the


### PR DESCRIPTION
Minor update: the existing yml generates an invalid key stanza upon restarting of a splunk instance.  This fixes the ss.conf stanza generation. 

