### PR TITLE
updated detection for long command line

### DIFF
--- a/detections/unusually_long_command_line___ssa.yml
+++ b/detections/unusually_long_command_line___ssa.yml
@@ -9,26 +9,33 @@ description: Command lines that are extremely long may be indicative of maliciou
 how_to_implement: You must be ingesting sysmon endpoint data that monitors command lines.
 references: []
 type: SSA
-author: Rico Valdez, Ignacio Bermudez Corrales, Splunk
+author: Ignacio Bermudez Corrales, Splunk
 search: ' | from read_ssa_enriched_events()
 | eval timestamp=parse_long(ucast(map_get(input_event, "_time"), "string", null))
 | eval cmd_line=ucast(map_get(input_event, "process"), "string", null),
 dest_user_id=ucast(map_get(input_event, "dest_user_id"), "string", null),
-input=parse_double(len(coalesce(cmd_line, ""))),
-dest_device_id=ucast(map_get(input_event, "dest_device_id"), "string", null)
+dest_device_id=ucast(map_get(input_event, "dest_device_id"), "string", null),
+process_name=ucast(map_get(input_event, "process_name"), "string", null)
 | where cmd_line!=null and dest_user_id!=null
-| adaptive_threshold algorithm="quantile" entity="dest_user_id" window=60480000
+| eval cmd_line_norm=replace(cast(cmd_line, "string"), /\s(--?\w+)|(\/\w+)/, " ARG"),
+cmd_line_norm=replace(cmd_line_norm, /\w:\\[^\s]+/, "PATH"),
+cmd_line_norm=replace(cmd_line_norm, /\d+/, "N"),
+input=parse_double(len(coalesce(cmd_line_norm, ""))),
+| adaptive_threshold algorithm="quantile" entity="process_name" window=60480000
 | where output="True" AND quantile>0.99
+| first_time_event cache_partitions=1 input_columns="dest_device_id,cmd_line"
+| where first_time_dest_device_id_cmd_line
 | eval start_time = timestamp,
 end_time = timestamp,
 entities = mvappend(dest_device_id, dest_user_id),
 body = "TBD"
 | into write_ssa_detected_events();'
-known_false_positives: Some legitimate applications use long command lines for installs
-  or updates. You should review identified command lines for legitimacy.
-  At the beginning of this search `adaptive_threshold` needs time to learn the baseline.
-  This search runs on a window of one week, if pattern of command line length changes over time,
-  some previously non suspiciously long commands can be suspicious in the current context.
+known_false_positives:
+  This detection may flag suspiciously long command lines when there is not sufficient evidence (samples) for a given
+  process that this detection is tracking; or when there is high variability in the length of the command line
+  for the tracked process.
+  Also, some legitimate applications may use long command lines. Such is the case of Ansible, that encodes
+  Powershell scripts using long base64. Attackers may use this technique to obfuscate their payloads.
 tags:
   kill_chain_phases:
   - Actions on Objectives


### PR DESCRIPTION
- Normalization of command line to compensate for length introduced by:
   - long arguments
   - paths in command line
   - consecutive digits
- Tracking length per application
- Report event on the first time it happens for one machine: Avoid repeated long commands used by automation tools like Ansible